### PR TITLE
Ohos 1686 exemplar help box http page and Ohos 1702 exemplar images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__/
+/db.sqlite3

--- a/home/static/comp-tool/kb/disco/media.csv
+++ b/home/static/comp-tool/kb/disco/media.csv
@@ -1,5 +1,5 @@
 URI,SmallURI,LargeURI,ImageWidth,Type,Priority,Caption,Taxon,Character,State,UseFor,TipStyle
-,,,,,,,,,,,
+resources/text/demo.html,,,,Html-local,1,,"William Raybould,…",,,,
 ,,,,,,,,,,,
 ,,,,,,,,,,,
 ,,,,,,,,,,,

--- a/home/static/comp-tool/kb/disco/resources/text/demo.html
+++ b/home/static/comp-tool/kb/disco/resources/text/demo.html
@@ -1,0 +1,25 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+</head>
+<body>
+    <h2>Example help window</h2>
+    <p>
+        In this window we can provide a lot of additional information, in a rich environment. 
+    </p>
+    <!-- examples showing some html-->
+    <ul> 
+        <li>
+            We can provide lists of data.
+        </li>
+        <li>
+            <span style="color: red">This box is capable of css</span>
+        </li>
+        <li>
+            <p class="demo">Its also capable of in-line javascript programming.</p>
+            <button type="button" onclick='document.getElementsByClassName("demo")[0].innerHTML = "See what Javascript can do!"''> Click me! </button> 
+        </li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
For the purpose of the OHOS show and tell, this PR adds an exemplar html page and image, to populate the “additional info” box that can be found when clicking on a record name in the UI. The exemplar html page shows that the tool can use standard html, css, and in-line javascript. It being capable of these three together means that we should be able to produce rich additional info boxes. 
Media.csv has been updated to point the UI at the right resources. 
I’ve also added a gitignore. Its currently ignoring .pyc files explicitly, and suggestions from Bernard relating to wagtail. 
